### PR TITLE
Fix use of non-standard keywords

### DIFF
--- a/clip2org.el
+++ b/clip2org.el
@@ -4,7 +4,7 @@
 ;; Version: 1.1
 ;; Time-stamp: <2012-05-28 10:53:45 thamer>
 ;; URL: https://github.com/thamer/clip2org
-;; Keywords: Kindle, Org mode, Amazon, My Clippings.txt
+;; Keywords: outlines
 ;; Compatibility: Tested on GNU Emacs 23.4 and 24.1
 ;; Copyright (C) 2012 Thamer Mahmoud, all rights reserved.
 
@@ -26,6 +26,8 @@
 ;; Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
+;;
+;; (Kindle, Org mode, Amazon, My Clippings.txt)
 ;;
 ;; This package converts Kindle's "My Clippings.txt" to a format
 ;; useable in Org mode. The result will be sorted by book title and


### PR DESCRIPTION
I ran [package-lint](https://github.com/purcell/package-lint) on clip2org.el as I thought about adding it to melpa. The following issues were found:

> 8:1: warning: You should include standard keywords: see the variable `finder-known-keywords'.

I.e. you are using
> ;; Keywords: Kindle, Org mode, Amazon, My Clippings.txt

But only the following keywords are "accepted" according to the [emacs manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).

```
finder-known-keywords is a variable defined in ‘finder.el’.
Its value is shown below.

Documentation:
Association list of the standard "Keywords:" headers.
Each element has the form (KEYWORD . DESCRIPTION).

Value: ((abbrev . "abbreviation handling, typing shortcuts, and macros")
 (bib . "bibliography processors")
 (c . "C and related programming languages")
 (calendar . "calendar and time management tools")
 (comm . "communications, networking, and remote file access")
 (convenience . "convenience features for faster editing")
 (data . "editing data (non-text) files")
 (docs . "Emacs documentation facilities")
 (emulations . "emulations of other editors")
 (extensions . "Emacs Lisp language extensions")
 (faces . "fonts and colors for text")
 (files . "file editing and manipulation")
 (frames . "Emacs frames and window systems")
 (games . "games, jokes and amusements")
 (hardware . "interfacing with system hardware")
 (help . "Emacs help systems")
 (hypermedia . "links between text or other media types")
 (i18n . "internationalization and character-set support")
 (internal . "code for Emacs internals, build process, defaults")
 (languages . "specialized modes for editing programming languages")
 (lisp . "Lisp support, including Emacs Lisp")
 (local . "code local to your site")
 (maint . "Emacs development tools and aids")
 (mail . "email reading and posting")
 (matching . "searching, matching, and sorting")
 (mouse . "mouse support")
 (multimedia . "images and sound")
 (news . "USENET news reading and posting")
 (outlines . "hierarchical outlining and note taking")
 (processes . "processes, subshells, and compilation")
 (terminals . "text terminals (ttys)")
 (tex . "the TeX document formatter")
 (tools . "programming tools")
 (unix . "UNIX feature interfaces and emulators")
 (vc . "version control")
 (wp . "word processing"))
```